### PR TITLE
updates to tests after feedback

### DIFF
--- a/src/uwtools/tests/drivers/test_driver.py
+++ b/src/uwtools/tests/drivers/test_driver.py
@@ -6,7 +6,7 @@ import json
 from pathlib import Path
 from textwrap import dedent
 from typing import Any, Dict
-from unittest.mock import Mock, patch
+from unittest.mock import Mock, PropertyMock, patch
 
 import pytest
 import yaml
@@ -37,7 +37,11 @@ class ConcreteDriver(driver.Driver):
 
     @property
     def _resources(self) -> Dict[str, Any]:
-        return {"some": "resource"}
+        return {
+            "account": "me",
+            "scheduler": "slurm",
+            "walltime": "01:10:00",
+        }
 
     def _taskname(self, suffix: str) -> str:
         return "concrete"
@@ -68,7 +72,7 @@ def driver_good(tmp_path):
         {
             "base_file": str(write(tmp_path / "base.yaml", {"a": 11, "b": 22})),
             "execution": {"executable": "qux", "mpiargs": ["bar", "baz"], "mpicmd": "foo"},
-            "update_values": {"a": 33},
+            "update_values": {"a": 33}, "run_dir": "/path/to/dir",
         },
     )
     return ConcreteDriver(config_file=cf, dry_run=True, batch=True)
@@ -155,6 +159,29 @@ def test_Driver__runscript_execution_only(driver_good):
     bar
     """
     assert driver_good._runscript(execution=["foo", "bar"]) == dedent(expected).strip()
+
+
+def test_Driver__run_via_batch_submission(driver_good):
+    runscript = driver_good._runscript_path
+    with patch.object(driver_good, "provisioned_run_directory") as prd:
+        with patch.object(ConcreteDriver, "_scheduler", new_callable=PropertyMock) as scheduler:
+            driver_good._run_via_batch_submission()
+            scheduler().submit_job.assert_called_once_with(
+                runscript=runscript, submit_file=Path(f"{runscript}.submit")
+            )
+        prd.assert_called_once_with()
+
+
+def test_Driver__run_via_local_execution(driver_good):
+    with patch.object(driver_good, "provisioned_run_directory") as prd:
+        with patch.object(driver, "execute") as execute:
+            driver_good._run_via_local_execution()
+            execute.assert_called_once_with(
+                cmd="{x} >{x}.out 2>&1".format(x=driver_good._runscript_path),
+                cwd=driver_good._rundir,
+                log_output=True,
+            )
+        prd.assert_called_once_with()
 
 
 def test_Driver__scheduler(driver_good):

--- a/src/uwtools/tests/drivers/test_sfc_climo_gen.py
+++ b/src/uwtools/tests/drivers/test_sfc_climo_gen.py
@@ -2,16 +2,15 @@
 """
 sfc_climo_gen driver tests.
 """
-from pathlib import Path
 from unittest.mock import DEFAULT as D
-from unittest.mock import PropertyMock, patch
+from unittest.mock import patch
 
 import f90nml  # type: ignore
 import yaml
 from iotaa import asset, external
 from pytest import fixture
 
-from uwtools.drivers import driver, sfc_climo_gen
+from uwtools.drivers import sfc_climo_gen
 
 config: dict = {
     "sfc_climo_gen": {
@@ -138,31 +137,6 @@ def test_SfcClimoGen_runscript(driverobj):
     # Check execution:
     assert "srun --export=ALL --ntasks $SLURM_CPUS_ON_NODE /path/to/sfc_climo_gen" in lines
     assert "test $? -eq 0 && touch %s/done" % driverobj._rundir
-
-
-def test_SfcClimoGen__run_via_batch_submission(driverobj):
-    runscript = driverobj._runscript_path
-    with patch.object(driverobj, "provisioned_run_directory") as prd:
-        with patch.object(
-            sfc_climo_gen.SfcClimoGen, "_scheduler", new_callable=PropertyMock
-        ) as scheduler:
-            driverobj._run_via_batch_submission()
-            scheduler().submit_job.assert_called_once_with(
-                runscript=runscript, submit_file=Path(f"{runscript}.submit")
-            )
-        prd.assert_called_once_with()
-
-
-def test_SfcClimoGen__run_via_local_execution(driverobj):
-    with patch.object(driverobj, "provisioned_run_directory") as prd:
-        with patch.object(driver, "execute") as execute:
-            driverobj._run_via_local_execution()
-            execute.assert_called_once_with(
-                cmd="{x} >{x}.out 2>&1".format(x=driverobj._runscript_path),
-                cwd=driverobj._rundir,
-                log_output=True,
-            )
-        prd.assert_called_once_with()
 
 
 def test_SfcClimoGen__driver_config(driverobj):


### PR DESCRIPTION
**Synopsis**

Exits to tests from feedback:
formatting changes
src path no longer used in tests
batch_submission and local_execution tests removed from test_chgres_cube and test_sfc_climo_gen and moved to test_driver

**Type**

- [x] Bug fix (corrects a known issue)
- [ ] Code maintenance (refactoring, etc. without behavior change)
- [ ] Documentation
- [ ] Enhancement (adds a new functionality)
- [ ] Tooling (CI, code-quality, packaging, revision-control, etc.)

**Impact**


- [x] This is a non-breaking change (existing functionality continues to work as expected)
- [ ] This is a breaking change (changes existing functionality)

**Checklist**


- [x] I have added myself and any co-authors to the PR's _Assignees_ list.
- [x] I have reviewed the documentation and have made any updates necessitated by this change.
